### PR TITLE
Search endpoint fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,30 +176,18 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
-<<<<<<< HEAD
-=======
-    
-    <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <scope>test</scope>
-    </dependency>
 
->>>>>>> 8604a1e39f81e71fafe7b3a247118a56afaeb315
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<version>2.28.2</version>
 			<scope>test</scope>
 		</dependency>
-<<<<<<< HEAD
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
-=======
->>>>>>> 8604a1e39f81e71fafe7b3a247118a56afaeb315
 
 
     </dependencies>

--- a/src/main/java/com/revature/rms/search/clients/EmployeeClient.java
+++ b/src/main/java/com/revature/rms/search/clients/EmployeeClient.java
@@ -14,13 +14,13 @@ import java.util.List;
 @FeignClient(name = "employee-service")
 public interface EmployeeClient {
 
-    @GetMapping( produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/employees" , produces = MediaType.APPLICATION_JSON_VALUE)
     public List<Employee> getAllEmployee();
 
     @GetMapping(value = "/id/{id}" , produces = MediaType.APPLICATION_JSON_VALUE)
     public Employee getEmployeeById(@PathVariable int id);
 
-    @GetMapping(value = "/getallbyid", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/getallbyid", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
     public List<Employee> getAllById(@RequestParam List<Integer> ids);
 
 }

--- a/src/main/java/com/revature/rms/search/controllers/SearchController.java
+++ b/src/main/java/com/revature/rms/search/controllers/SearchController.java
@@ -33,35 +33,37 @@ public class SearchController {
     this.etlService = service;
   }
 
-  // Get all campuses
+  // Get all campuses -- Fixed Added Missing Employee Department DTO Enums and Works fine
   @GetMapping(value = "/campuses", produces = MediaType.APPLICATION_JSON_VALUE)
   public List<CampusDto> findAllCampuses() {
     return etlService.getAllCampuses();
   }
 
-  // Grab the campus by Id
+  // Grab the campus by Id -- works fine
   @GetMapping(value = "/campus/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
   public CampusDto findCampusById(@PathVariable("id") String id) {
     return etlService.getCampusDtoById(id);
   }
 
-  // Get building by Id
+  // Get building by Id -- Works fine, mongodb was creating hash values for Ids instead of integers, changed Ids for dummy data in Campus Service
   @GetMapping(value = "/building/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
   public BuildingDto findBuildingById(@PathVariable("id") String id) {
     return etlService.getBuildingDtoById(id);
   }
 
-  // Get room by id
+  // Get room by id - Works fine, mongodb Entity's primary key is a string so the ids need to be string in order to work.
   @GetMapping(value = "/room/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
   public RoomDto findRoomById(@PathVariable("id") String id) {
     return etlService.getRoomDtoById(id);
   }
 
+  //Get employees - Works fine, Employee Client needed to have the additional path of /employees to match the Employee Service
   @GetMapping(value = "/employees", produces = MediaType.APPLICATION_JSON_VALUE)
   public List<EmployeeDto> findAllEmployees() {
     return etlService.getAllEmployees();
   }
 
+  //Get employee by id - Works fine
   @GetMapping(value = "/employee/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
   public EmployeeDto findEmployeeById(@PathVariable("id") int id) {
     return etlService.getEmployeeById(id);

--- a/src/main/java/com/revature/rms/search/entites/employee/Department.java
+++ b/src/main/java/com/revature/rms/search/entites/employee/Department.java
@@ -5,7 +5,9 @@ public enum Department {
   STAGING("Dev"),
   QC("Qc"),
   RETENTION("Retention"),
-  HR("Hr");
+  HR("Hr"),
+  RECRUITMENT("RECRUITMENT"),
+  DELIVERY("DELIVERY");
 
   private String department;
 


### PR DESCRIPTION
Deleted conflicting merging in POM, modify EmployeeClient value path to match Employee Service and the consuming media type JSON so that feign client knows what header to send. Additional commenting on endpoints on what fixed was done for each. Added missing Enums for Department DTO
